### PR TITLE
Add Guangdong Hongzhong (红中赖子) Mahjong WeChat mini-program demo

### DIFF
--- a/mahjong-miniprogram/app.js
+++ b/mahjong-miniprogram/app.js
@@ -1,0 +1,6 @@
+App({
+  globalData: {
+    playerName: '玩家',
+    score: 0,
+  },
+});

--- a/mahjong-miniprogram/app.json
+++ b/mahjong-miniprogram/app.json
@@ -1,0 +1,15 @@
+{
+  "pages": [
+    "pages/index/index",
+    "pages/game/game",
+    "pages/score/score"
+  ],
+  "window": {
+    "navigationBarTitleText": "广东红中赖子麻将",
+    "navigationBarBackgroundColor": "#0F6D3F",
+    "navigationBarTextStyle": "white",
+    "backgroundColor": "#0B3B22"
+  },
+  "style": "v2",
+  "sitemapLocation": "sitemap.json"
+}

--- a/mahjong-miniprogram/app.wxss
+++ b/mahjong-miniprogram/app.wxss
@@ -1,0 +1,24 @@
+page {
+  font-family: "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: #0b3b22;
+  color: #f7f7f7;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #f8c05e, #f08e2a);
+  color: #2a1b00;
+  border-radius: 999px;
+  padding: 18rpx 40rpx;
+  font-weight: 600;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 24rpx;
+  padding: 24rpx;
+  box-shadow: 0 18rpx 36rpx rgba(0, 0, 0, 0.25);
+}
+
+.text-muted {
+  color: rgba(255, 255, 255, 0.7);
+}

--- a/mahjong-miniprogram/pages/game/game.js
+++ b/mahjong-miniprogram/pages/game/game.js
@@ -1,0 +1,110 @@
+const mahjong = require("../../utils/mahjong");
+
+const buildInitialHand = (wall, count = 13) => {
+  let currentWall = wall;
+  const hand = [];
+  for (let i = 0; i < count; i += 1) {
+    const result = mahjong.drawTile(currentWall);
+    hand.push(result.tile);
+    currentWall = result.wall;
+  }
+  return { hand, wall: currentWall };
+};
+
+Page({
+  data: {
+    wall: [],
+    wallCount: 0,
+    hand: [],
+    melds: [],
+    discard: {},
+    canPeng: false,
+    score: 0,
+  },
+
+  onLoad() {
+    this.initGame();
+  },
+
+  initGame() {
+    const wall = mahjong.buildWall();
+    const { hand, wall: newWall } = buildInitialHand(wall);
+    this.setData({
+      wall: newWall,
+      wallCount: newWall.length,
+      hand,
+      melds: [],
+      discard: {},
+      canPeng: false,
+      score: 0,
+    });
+  },
+
+  discardTile(event) {
+    const { id } = event.currentTarget.dataset;
+    const { hand } = this.data;
+    const tileIndex = hand.findIndex((tile) => tile.id === id);
+    if (tileIndex === -1) {
+      return;
+    }
+    const discard = hand[tileIndex];
+    const newHand = hand.slice();
+    newHand.splice(tileIndex, 1);
+    const canPeng = mahjong.canPeng(newHand, discard);
+    this.setData({
+      hand: newHand,
+      discard,
+      canPeng,
+    });
+  },
+
+  drawFromWall() {
+    const { wall, hand } = this.data;
+    if (wall.length === 0) {
+      wx.showToast({
+        title: "牌墙已空",
+        icon: "none",
+      });
+      return;
+    }
+    const result = mahjong.drawTile(wall);
+    this.setData({
+      wall: result.wall,
+      wallCount: result.wall.length,
+      hand: [...hand, result.tile],
+    });
+  },
+
+  handlePeng() {
+    const { canPeng, hand, discard, melds, score } = this.data;
+    if (!canPeng) {
+      return;
+    }
+    const { newHand, meld } = mahjong.applyPeng(hand, discard);
+    const laiziCount = mahjong.countLaizi(newHand);
+    const roundScore = mahjong.calculateScore({
+      melds: [...melds, meld],
+      laiziCount,
+      winType: "peng",
+    });
+    this.setData({
+      hand: newHand,
+      melds: [...melds, meld],
+      discard: {},
+      canPeng: false,
+      score: score + roundScore,
+    });
+  },
+
+  goScore() {
+    const { score, melds, hand } = this.data;
+    wx.setStorageSync("mahjongScore", {
+      score,
+      melds,
+      hand,
+    });
+    wx.navigateTo({
+      url: "/pages/score/score",
+    });
+  },
+});

--- a/mahjong-miniprogram/pages/game/game.json
+++ b/mahjong-miniprogram/pages/game/game.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "对局桌面"
+}

--- a/mahjong-miniprogram/pages/game/game.wxml
+++ b/mahjong-miniprogram/pages/game/game.wxml
@@ -1,0 +1,45 @@
+<view class="page">
+  <view class="table-header">
+    <view>
+      <text class="table-title">当前回合</text>
+      <text class="table-subtitle text-muted">墙内剩余：{{wallCount}} 张</text>
+    </view>
+    <view class="score-card">
+      <text class="score-label">积分</text>
+      <text class="score-value">{{score}}</text>
+    </view>
+  </view>
+
+  <view class="card meld-card">
+    <text class="section-title">已碰牌</text>
+    <view class="melds">
+      <view class="meld" wx:for="{{melds}}" wx:key="index">
+        <text wx:for="{{item}}" wx:key="id" class="tile tile-meld">{{item.label}}</text>
+      </view>
+      <text wx:if="{{melds.length === 0}}" class="text-muted">暂无碰牌</text>
+    </view>
+  </view>
+
+  <view class="card discard-card">
+    <text class="section-title">上一张牌</text>
+    <view class="discard">
+      <text class="tile tile-discard">{{discard.label}}</text>
+      <text class="text-muted" wx:if="{{!discard.label}}">等待出牌</text>
+    </view>
+    <button class="button-primary" bindtap="handlePeng" disabled="{{!canPeng}}">碰牌</button>
+  </view>
+
+  <view class="card hand-card">
+    <text class="section-title">我的手牌</text>
+    <view class="hand">
+      <text wx:for="{{hand}}" wx:key="id" class="tile" bindtap="discardTile" data-id="{{item.id}}">
+        {{item.label}}
+      </text>
+    </view>
+  </view>
+
+  <view class="action-bar">
+    <button class="ghost" bindtap="drawFromWall">摸牌</button>
+    <button class="ghost" bindtap="goScore">结算</button>
+  </view>
+</view>

--- a/mahjong-miniprogram/pages/game/game.wxss
+++ b/mahjong-miniprogram/pages/game/game.wxss
@@ -1,0 +1,109 @@
+.page {
+  padding: 32rpx 24rpx 48rpx;
+}
+
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24rpx;
+}
+
+.table-title {
+  font-size: 34rpx;
+  font-weight: 600;
+}
+
+.table-subtitle {
+  font-size: 22rpx;
+  margin-top: 8rpx;
+  display: block;
+}
+
+.score-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 16rpx 24rpx;
+  border-radius: 16rpx;
+  text-align: right;
+}
+
+.score-label {
+  font-size: 20rpx;
+  color: rgba(255, 255, 255, 0.7);
+  display: block;
+}
+
+.score-value {
+  font-size: 36rpx;
+  font-weight: 700;
+}
+
+.section-title {
+  font-size: 26rpx;
+  font-weight: 600;
+  margin-bottom: 16rpx;
+}
+
+.meld-card,
+.discard-card,
+.hand-card {
+  margin-bottom: 24rpx;
+}
+
+.melds {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.meld {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+}
+
+.discard {
+  margin-bottom: 16rpx;
+  min-height: 72rpx;
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.hand {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+}
+
+.tile {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 14rpx 18rpx;
+  border-radius: 16rpx;
+  font-size: 22rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.15);
+}
+
+.tile-meld {
+  background: rgba(248, 192, 94, 0.2);
+}
+
+.tile-discard {
+  background: rgba(240, 142, 42, 0.3);
+  font-weight: 600;
+}
+
+.action-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16rpx;
+}
+
+.ghost {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1rpx solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 16rpx 24rpx;
+}

--- a/mahjong-miniprogram/pages/index/index.js
+++ b/mahjong-miniprogram/pages/index/index.js
@@ -1,0 +1,7 @@
+Page({
+  startGame() {
+    wx.navigateTo({
+      url: "/pages/game/game",
+    });
+  },
+});

--- a/mahjong-miniprogram/pages/index/index.json
+++ b/mahjong-miniprogram/pages/index/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "红中赖子麻将"
+}

--- a/mahjong-miniprogram/pages/index/index.wxml
+++ b/mahjong-miniprogram/pages/index/index.wxml
@@ -1,0 +1,23 @@
+<view class="page">
+  <view class="hero">
+    <text class="title">广东红中赖子麻将</text>
+    <text class="subtitle">四人对局 · 红中当赖子 · 经典碰碰胡节奏</text>
+  </view>
+
+  <view class="card mode-card">
+    <view class="mode">
+      <text class="mode-title">标准玩法</text>
+      <text class="mode-desc text-muted">含碰牌、赖子、基础积分结算</text>
+    </view>
+    <button class="button-primary" bindtap="startGame">开始对局</button>
+  </view>
+
+  <view class="card info-card">
+    <text class="info-title">特色</text>
+    <view class="info-list">
+      <text>• 红中赖子可替代任意牌</text>
+      <text>• 碰牌快速成型，适合快节奏对战</text>
+      <text>• 内置积分计算展示</text>
+    </view>
+  </view>
+</view>

--- a/mahjong-miniprogram/pages/index/index.wxss
+++ b/mahjong-miniprogram/pages/index/index.wxss
@@ -1,0 +1,53 @@
+.page {
+  padding: 48rpx 32rpx 64rpx;
+}
+
+.hero {
+  margin-bottom: 48rpx;
+}
+
+.title {
+  font-size: 48rpx;
+  font-weight: 700;
+  display: block;
+  margin-bottom: 16rpx;
+}
+
+.subtitle {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  margin-bottom: 32rpx;
+}
+
+.mode-title {
+  font-size: 32rpx;
+  font-weight: 600;
+}
+
+.mode-desc {
+  font-size: 24rpx;
+  margin-top: 8rpx;
+}
+
+.info-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+
+.info-title {
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.info-list text {
+  display: block;
+  font-size: 24rpx;
+  margin-bottom: 8rpx;
+}

--- a/mahjong-miniprogram/pages/score/score.js
+++ b/mahjong-miniprogram/pages/score/score.js
@@ -1,0 +1,24 @@
+Page({
+  data: {
+    score: 0,
+    melds: [],
+    hand: [],
+    meldCount: 0,
+  },
+
+  onShow() {
+    const data = wx.getStorageSync("mahjongScore") || {};
+    this.setData({
+      score: data.score || 0,
+      melds: data.melds || [],
+      hand: data.hand || [],
+      meldCount: (data.melds || []).length,
+    });
+  },
+
+  backToHome() {
+    wx.reLaunch({
+      url: "/pages/index/index",
+    });
+  },
+});

--- a/mahjong-miniprogram/pages/score/score.json
+++ b/mahjong-miniprogram/pages/score/score.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "积分结算"
+}

--- a/mahjong-miniprogram/pages/score/score.wxml
+++ b/mahjong-miniprogram/pages/score/score.wxml
@@ -1,0 +1,26 @@
+<view class="page">
+  <view class="card summary-card">
+    <text class="title">本局积分</text>
+    <text class="score">{{score}}</text>
+    <text class="text-muted">碰牌次数：{{meldCount}}</text>
+  </view>
+
+  <view class="card detail-card">
+    <text class="section-title">手牌预览</text>
+    <view class="hand">
+      <text wx:for="{{hand}}" wx:key="id" class="tile">{{item.label}}</text>
+    </view>
+  </view>
+
+  <view class="card detail-card">
+    <text class="section-title">碰牌详情</text>
+    <view class="melds">
+      <view class="meld" wx:for="{{melds}}" wx:key="index">
+        <text wx:for="{{item}}" wx:key="id" class="tile tile-meld">{{item.label}}</text>
+      </view>
+      <text wx:if="{{melds.length === 0}}" class="text-muted">暂无碰牌</text>
+    </view>
+  </view>
+
+  <button class="button-primary" bindtap="backToHome">返回首页</button>
+</view>

--- a/mahjong-miniprogram/pages/score/score.wxss
+++ b/mahjong-miniprogram/pages/score/score.wxss
@@ -1,0 +1,50 @@
+.page {
+  padding: 40rpx 24rpx 64rpx;
+}
+
+.summary-card {
+  text-align: center;
+  margin-bottom: 32rpx;
+}
+
+.title {
+  font-size: 30rpx;
+  margin-bottom: 12rpx;
+  display: block;
+}
+
+.score {
+  font-size: 64rpx;
+  font-weight: 700;
+  margin-bottom: 16rpx;
+  display: block;
+}
+
+.section-title {
+  font-size: 26rpx;
+  font-weight: 600;
+  margin-bottom: 16rpx;
+}
+
+.detail-card {
+  margin-bottom: 24rpx;
+}
+
+.hand,
+.melds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+}
+
+.tile {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 14rpx 18rpx;
+  border-radius: 16rpx;
+  font-size: 22rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.15);
+}
+
+.tile-meld {
+  background: rgba(248, 192, 94, 0.2);
+}

--- a/mahjong-miniprogram/project.config.json
+++ b/mahjong-miniprogram/project.config.json
@@ -1,0 +1,12 @@
+{
+  "miniprogramRoot": "./",
+  "projectname": "guangdong-hongzhong-mahjong",
+  "description": "广东红中赖子麻将小程序演示",
+  "appid": "touristappid",
+  "setting": {
+    "urlCheck": false,
+    "es6": true,
+    "enhance": true,
+    "minified": false
+  }
+}

--- a/mahjong-miniprogram/sitemap.json
+++ b/mahjong-miniprogram/sitemap.json
@@ -1,0 +1,8 @@
+{
+  "rules": [
+    {
+      "action": "allow",
+      "page": "*"
+    }
+  ]
+}

--- a/mahjong-miniprogram/utils/mahjong.js
+++ b/mahjong-miniprogram/utils/mahjong.js
@@ -1,0 +1,143 @@
+const SUITS = ["wan", "tiao", "tong"];
+const NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const WINDS = ["east", "south", "west", "north"];
+const DRAGONS = ["red", "green", "white"];
+
+const tileNameMap = {
+  wan: "万",
+  tiao: "条",
+  tong: "筒",
+  east: "东",
+  south: "南",
+  west: "西",
+  north: "北",
+  red: "红中",
+  green: "发财",
+  white: "白板",
+};
+
+const createSuitTiles = () => {
+  const tiles = [];
+  SUITS.forEach((suit) => {
+    NUMBERS.forEach((value) => {
+      for (let i = 0; i < 4; i += 1) {
+        tiles.push({
+          id: `${suit}-${value}-${i}`,
+          type: suit,
+          value,
+          label: `${value}${tileNameMap[suit]}`,
+        });
+      }
+    });
+  });
+  return tiles;
+};
+
+const createHonorTiles = () => {
+  const tiles = [];
+  WINDS.forEach((wind) => {
+    for (let i = 0; i < 4; i += 1) {
+      tiles.push({
+        id: `${wind}-${i}`,
+        type: "wind",
+        value: wind,
+        label: tileNameMap[wind],
+      });
+    }
+  });
+  DRAGONS.forEach((dragon) => {
+    for (let i = 0; i < 4; i += 1) {
+      tiles.push({
+        id: `${dragon}-${i}`,
+        type: "dragon",
+        value: dragon,
+        label: tileNameMap[dragon],
+      });
+    }
+  });
+  return tiles;
+};
+
+const shuffle = (tiles) => {
+  const copy = tiles.slice();
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+};
+
+const buildWall = () => shuffle([...createSuitTiles(), ...createHonorTiles()]);
+
+const isLaizi = (tile) => tile && tile.type === "dragon" && tile.value === "red";
+
+const countMatching = (hand, target) =>
+  hand.filter((tile) => tile.type === target.type && tile.value === target.value).length;
+
+const countLaizi = (hand) => hand.filter(isLaizi).length;
+
+const canPeng = (hand, discard) => {
+  const matchCount = countMatching(hand, discard);
+  if (matchCount >= 2) {
+    return true;
+  }
+  return matchCount === 1 && countLaizi(hand) >= 1;
+};
+
+const applyPeng = (hand, discard) => {
+  const newHand = hand.slice();
+  const meld = [discard];
+  const takeIndex = newHand.findIndex(
+    (tile) => tile.type === discard.type && tile.value === discard.value
+  );
+  if (takeIndex !== -1) {
+    meld.push(newHand.splice(takeIndex, 1)[0]);
+  }
+  if (meld.length < 3) {
+    const laiziIndex = newHand.findIndex(isLaizi);
+    if (laiziIndex !== -1) {
+      meld.push({
+        ...newHand.splice(laiziIndex, 1)[0],
+        label: "红中(赖子)",
+      });
+    }
+  }
+  const secondIndex = newHand.findIndex(
+    (tile) => tile.type === discard.type && tile.value === discard.value
+  );
+  if (meld.length < 3 && secondIndex !== -1) {
+    meld.push(newHand.splice(secondIndex, 1)[0]);
+  }
+  return { newHand, meld };
+};
+
+const drawTile = (wall) => {
+  const newWall = wall.slice();
+  const tile = newWall.shift();
+  return { tile, wall: newWall };
+};
+
+const calculateScore = ({ melds, laiziCount, winType }) => {
+  let score = 1;
+  score += melds.length;
+  if (laiziCount > 0) {
+    score += laiziCount;
+  }
+  if (winType === "self") {
+    score += 2;
+  }
+  if (winType === "peng") {
+    score += 1;
+  }
+  return score;
+};
+
+module.exports = {
+  buildWall,
+  drawTile,
+  canPeng,
+  applyPeng,
+  calculateScore,
+  isLaizi,
+  countLaizi,
+};


### PR DESCRIPTION
### Motivation
- Provide a small, runnable WeChat Mini Program demo that implements Guangdong Red-Dragon (红中) laizi mahjong with a UI and basic backend game logic for prototyping and UX validation.

### Description
- Add mini-program scaffold and configuration files including `app.js`, `app.json`, `project.config.json`, and `sitemap.json` to register pages and global settings.
- Implement core game utilities in `utils/mahjong.js` with `buildWall`, `drawTile`, laizi detection `isLaizi`, `canPeng`, `applyPeng`, `countLaizi`, and `calculateScore` to support laizi and Peng logic.
- Add three pages for the flow: home (`pages/index/*`), game table (`pages/game/*`) and score summary (`pages/score/*`), with UI, styling, and interaction handlers for `drawFromWall`, `discardTile`, `handlePeng`, and `goScore` that persist results via `wx.setStorageSync`.
- Wire the pages to use the utilities and present melds, hand tiles, discard state, wall count, and running score in the UI with responsive styling.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b179912248320a481d1202b75aa22)